### PR TITLE
attempt to do /dev/null-based mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "btree_monstrousity"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec92912346b936c974181a172d9abc81f50d41e40118fc101dac8aa8134bee3"
+dependencies = [
+ "cfg-if",
+ "rustversion",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,6 +1849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2107,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rawpointer",
+]
+
+[[package]]
+name = "nodit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74369f80df24efd2266602fdcd8fcd56a17c2e2c94ab48d2f7a15eaa137bf49"
+dependencies = [
+ "btree_monstrousity",
+ "itertools 0.13.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -3845,6 +3875,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
+ "nodit",
  "object",
  "once_cell",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,6 +308,7 @@ similar = "2.1.0"
 toml = "0.8.10"
 mach2 = "0.4.2"
 memfd = "0.6.2"
+nodit = "0.9.2"
 psm = "0.1.11"
 proptest = "1.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -92,6 +92,7 @@ mach2 = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, optional = true }
+nodit = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 psm = { workspace = true, optional = true }
@@ -238,6 +239,7 @@ runtime = [
   "dep:windows-sys",
   "dep:psm",
   "dep:rustix",
+  "dep:nodit",
   "rustix/mm",
   "pulley-interpreter?/interp",
 ]

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -451,7 +451,10 @@ pub trait InstanceAllocator: InstanceAllocatorImpl {
                 .defined_memory_index(memory_index)
                 .expect("should be a defined memory since we skipped imported ones");
 
-            memories.push(self.allocate_memory(request, ty, request.tunables, memory_index)?);
+            memories.push(
+                self.allocate_memory(request, ty, request.tunables, memory_index)
+                    .context("allocate_memory failed")?,
+            );
         }
 
         Ok(())

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -617,9 +617,13 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
         let mut image = memory.unwrap_static_image();
         let mut queue = DecommitQueue::default();
         image
-            .clear_and_remain_ready(self.memories.keep_resident, |ptr, len| {
-                queue.push_raw(ptr, len);
-            })
+            .clear_and_remain_ready(
+                self.memories.mapping(),
+                self.memories.keep_resident,
+                |ptr, len| {
+                    queue.push_raw(ptr, len);
+                },
+            )
             .expect("failed to reset memory image");
         queue.push_memory(allocation_index, image);
         self.merge_or_flush(queue);

--- a/crates/wasmtime/src/runtime/vm/sys/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/mod.rs
@@ -47,10 +47,7 @@ fn empty_mmap() -> SendSyncPtr<[u8]> {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(miri)] {
-        mod miri;
-        pub use miri::*;
-    } else if #[cfg(windows)] {
+    if #[cfg(windows)] {
         mod windows;
         pub use windows::*;
     } else if #[cfg(unix)] {

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -1,15 +1,15 @@
 use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
+use core::mem::ManuallyDrop;
+use nodit::interval::ie;
+use nodit::{Interval, NoditSet};
 use rustix::mm::{mprotect, MprotectFlags};
 use std::ops::Range;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::ptr::{self, NonNull};
+use std::sync::Mutex;
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path};
-
-#[derive(Debug)]
-pub struct Mmap {
-    memory: SendSyncPtr<[u8]>,
-}
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "illumos", target_os = "linux"))] {
@@ -28,14 +28,219 @@ cfg_if::cfg_if! {
     }
 }
 
+#[derive(Debug)]
+pub struct Mmap {
+    imp: MmapImpl,
+}
+
 impl Mmap {
+    #[inline]
     pub fn new_empty() -> Mmap {
-        Mmap {
-            memory: crate::vm::sys::empty_mmap(),
+        Self {
+            imp: MmapImpl::new_empty(),
         }
     }
 
-    pub fn new(size: usize) -> Result<Self> {
+    #[inline]
+    pub fn new(size: usize) -> Result<Mmap> {
+        Ok(Self {
+            imp: MmapImpl::new(size)?,
+        })
+    }
+
+    #[inline]
+    pub fn reserve(size: usize) -> Result<Mmap> {
+        Ok(Self {
+            imp: MmapImpl::reserve(size)?,
+        })
+    }
+
+    #[cfg(feature = "std")]
+    pub fn from_file(path: &Path) -> Result<(Self, File)> {
+        let (imp, file) = MmapImpl::from_file(path)?;
+        Ok((Self { imp }, file))
+    }
+
+    #[inline]
+    pub fn make_accessible(&self, start: usize, len: usize) -> Result<()> {
+        self.imp.make_accessible(start, len)
+    }
+
+    #[inline]
+    pub unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        self.imp.make_executable(range, enable_branch_protection)
+    }
+
+    #[inline]
+    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        self.imp.make_readonly(range)
+    }
+
+    #[inline]
+    pub unsafe fn make_inaccessible(&self, range: Range<usize>) -> Result<()> {
+        self.imp.make_inaccessible(range)
+    }
+
+    #[inline]
+    pub unsafe fn decommit(&self, range: Range<usize>) -> Result<()> {
+        self.imp.decommit(range)
+    }
+
+    #[inline]
+    pub unsafe fn map_fd<Fd: AsFd>(
+        &self,
+        start: usize,
+        fd: Fd,
+        len: usize,
+        offset: u64,
+    ) -> Result<()> {
+        self.imp.map_fd(start, fd.as_fd(), len, offset)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.imp.as_ptr()
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.imp.as_mut_ptr()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.imp.len()
+    }
+}
+
+#[derive(Debug)]
+enum MmapImpl {
+    Regular(MmapRegular),
+    DevNull(MmapDevNull),
+}
+
+impl MmapImpl {
+    #[inline]
+    fn new_empty() -> Self {
+        Self::Regular(MmapRegular::new_empty())
+    }
+
+    #[inline]
+    fn new(size: usize) -> Result<Self> {
+        Ok(Self::Regular(MmapRegular::new_read_write(size)?))
+    }
+
+    #[inline]
+    fn reserve(size: usize) -> Result<Self> {
+        Ok(Self::DevNull(MmapDevNull::reserve(size)?))
+    }
+
+    #[cfg(feature = "std")]
+    fn from_file(path: &Path) -> Result<(Self, File)> {
+        let (imp, file) = MmapRegular::from_file(path)?;
+        Ok((Self::Regular(imp), file))
+    }
+
+    #[inline]
+    fn make_accessible(&self, start: usize, len: usize) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.make_accessible(start, len),
+            Self::DevNull(imp) => imp.make_accessible(start, len),
+        }
+    }
+
+    #[inline]
+    unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.make_executable(range, enable_branch_protection),
+            Self::DevNull(imp) => imp.make_executable(range, enable_branch_protection),
+        }
+    }
+
+    #[inline]
+    unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.make_readonly(range),
+            Self::DevNull(imp) => imp.make_readonly(range),
+        }
+    }
+
+    #[inline]
+    unsafe fn make_inaccessible(&self, range: Range<usize>) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.make_inaccessible(range),
+            Self::DevNull(imp) => imp.make_inaccessible(range),
+        }
+    }
+
+    #[inline]
+    unsafe fn decommit(&self, range: Range<usize>) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.decommit(range),
+            Self::DevNull(imp) => imp.decommit(range),
+        }
+    }
+
+    #[inline]
+    unsafe fn map_fd(
+        &self,
+        start: usize,
+        fd: BorrowedFd<'_>,
+        len: usize,
+        offset: u64,
+    ) -> Result<()> {
+        match self {
+            Self::Regular(imp) => imp.map_fd(start, fd, len, offset),
+            Self::DevNull(imp) => imp.map_fd(start, fd, len, offset),
+        }
+    }
+
+    #[inline]
+    fn as_ptr(&self) -> *const u8 {
+        match self {
+            Self::Regular(imp) => imp.memory.as_ptr() as *const u8,
+            Self::DevNull(imp) => imp.memory.as_ptr() as *const u8,
+        }
+    }
+
+    #[inline]
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        match self {
+            Self::Regular(imp) => imp.memory.as_ptr().cast(),
+            Self::DevNull(imp) => imp.memory.as_ptr().cast(),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            Self::Regular(imp) => imp.memory.as_ptr().len(),
+            Self::DevNull(imp) => imp.memory.as_ptr().len(),
+        }
+    }
+}
+
+/// An mmap impl that's backed by a single `mmap` call, whether anonymous or file-backed.
+#[derive(Debug)]
+struct MmapRegular {
+    memory: SendSyncPtr<[u8]>,
+}
+
+impl MmapRegular {
+    fn new_empty() -> Self {
+        let memory = crate::vm::sys::empty_mmap();
+        Self { memory }
+    }
+
+    fn new_read_write(size: usize) -> Result<Self> {
         let ptr = unsafe {
             rustix::mm::mmap_anonymous(
                 ptr::null_mut(),
@@ -47,10 +252,10 @@ impl Mmap {
         };
         let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
         let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
-        Ok(Mmap { memory })
+        Ok(Self { memory })
     }
 
-    pub fn reserve(size: usize) -> Result<Self> {
+    fn reserve(size: usize) -> Result<Self> {
         let ptr = unsafe {
             rustix::mm::mmap_anonymous(
                 ptr::null_mut(),
@@ -74,11 +279,11 @@ impl Mmap {
 
         let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
         let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
-        Ok(Mmap { memory })
+        Ok(Self { memory })
     }
 
     #[cfg(feature = "std")]
-    pub fn from_file(path: &Path) -> Result<(Self, File)> {
+    fn from_file(path: &Path) -> Result<(Self, File)> {
         let file = File::open(path)
             .err2anyhow()
             .context("failed to open file")?;
@@ -103,10 +308,10 @@ impl Mmap {
         let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), len);
         let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
 
-        Ok((Mmap { memory }, file))
+        Ok((Self { memory }, file))
     }
 
-    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
+    fn make_accessible(&self, start: usize, len: usize) -> Result<()> {
         let ptr = self.memory.as_ptr();
         unsafe {
             mprotect(
@@ -120,22 +325,7 @@ impl Mmap {
         Ok(())
     }
 
-    #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
-        self.memory.as_ptr().cast()
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.memory.as_ptr().len()
-    }
-
-    pub unsafe fn make_executable(
+    unsafe fn make_executable(
         &self,
         range: Range<usize>,
         enable_branch_protection: bool,
@@ -163,18 +353,347 @@ impl Mmap {
         Ok(())
     }
 
-    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
-        let base = self.memory.as_ptr().byte_add(range.start).cast();
+    unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
         let len = range.end - range.start;
+        if len == 0 {
+            return Ok(());
+        }
+
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
 
         mprotect(base, len, MprotectFlags::READ).err2anyhow()?;
 
         Ok(())
     }
+
+    unsafe fn make_inaccessible(&self, range: Range<usize>) -> Result<()> {
+        let len = range.end - range.start;
+        if len == 0 {
+            return Ok(());
+        }
+
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
+
+        mprotect(base, len, MprotectFlags::empty()).err2anyhow()?;
+
+        Ok(())
+    }
+
+    unsafe fn decommit(&self, range: Range<usize>) -> Result<()> {
+        let len = range.end - range.start;
+        if len == 0 {
+            return Ok(());
+        }
+
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
+
+        unsafe {
+            cfg_if::cfg_if! {
+                if #[cfg(target_os = "linux")] {
+                    use rustix::mm::{madvise, Advice};
+
+                    // On Linux, this is enough to cause the kernel to initialize
+                    // the pages to 0 on next access
+                    madvise(base, len, Advice::LinuxDontNeed)?;
+                } else {
+                    // By creating a new mapping at the same location, this will
+                    // discard the mapping for the pages in the given range.
+                    // The new mapping will be to the CoW zero page, so this
+                    // effectively zeroes the pages.
+                    rustix::mm::mmap_anonymous(
+                        base,
+                        len,
+                        rustix::mm::ProtFlags::READ
+                            | rustix::mm::ProtFlags::WRITE,
+                        rustix::mm::MapFlags::PRIVATE
+                            | super::mmap::MMAP_NORESERVE_FLAG
+                            | rustix::mm::MapFlags::FIXED,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    unsafe fn map_fd(
+        &self,
+        start: usize,
+        fd: BorrowedFd<'_>,
+        len: usize,
+        offset: u64,
+    ) -> Result<()> {
+        let base = self.memory.as_ptr().byte_add(start).cast();
+        rustix::mm::mmap(
+            base,
+            len,
+            rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
+            rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
+            fd,
+            offset,
+        )
+        .err2anyhow()?;
+
+        Ok(())
+    }
 }
 
-impl Drop for Mmap {
+impl Drop for MmapRegular {
     fn drop(&mut self) {
+        unsafe {
+            let ptr = self.memory.as_ptr().cast();
+            let len = self.memory.as_ptr().len();
+            if len == 0 {
+                return;
+            }
+            rustix::mm::munmap(ptr, len).expect("munmap failed");
+        }
+    }
+}
+
+/// An mmap impl based on `/dev/null` for PROT_NONE regions.
+#[derive(Debug)]
+struct MmapDevNull {
+    memory: SendSyncPtr<[u8]>,
+    // The mutex is required because some of the anon_ranges APIs take &self.
+    anon_ranges: Mutex<NoditSet<usize, Interval<usize>>>,
+}
+
+impl MmapDevNull {
+    fn reserve(size: usize) -> Result<Self> {
+        // With mmap, the fd doesn't need to be kept open after the mmap call, so we can drop it at
+        // the end of the function.
+        let fd = File::open("/dev/null")
+            .err2anyhow()
+            .context("error opening /dev/null")?;
+        let ptr = unsafe {
+            rustix::mm::mmap(
+                ptr::null_mut(),
+                size,
+                rustix::mm::ProtFlags::empty(),
+                rustix::mm::MapFlags::PRIVATE | MMAP_NORESERVE_FLAG,
+                &fd,
+                0,
+            )
+            .err2anyhow()
+            .context("mmap call failed")?
+        };
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
+        let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
+        Ok(MmapDevNull {
+            memory,
+            anon_ranges: Mutex::new(NoditSet::new()),
+        })
+    }
+
+    fn make_accessible(&self, start: usize, len: usize) -> Result<()> {
+        let end = start
+            .checked_add(len)
+            .ok_or_else(|| anyhow::anyhow!("overflow in {start} + {len}"))?;
+        self.operate_on(start, end, Op::MakeAccessible)
+    }
+
+    unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        self.operate_on(
+            range.start,
+            range.end,
+            Op::MakeExecutable {
+                enable_branch_protection,
+            },
+        )
+    }
+
+    unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        self.operate_on(range.start, range.end, Op::MakeReadonly)
+    }
+
+    unsafe fn make_inaccessible(&self, range: Range<usize>) -> Result<()> {
+        self.operate_on(range.start, range.end, Op::MakeProtected)
+    }
+
+    // Operate on [start, end) with the given operation.
+    fn operate_on(&self, start: usize, end: usize, op: Op) -> Result<()> {
+        // nodit panics on zero-length intervals so we need an explicit check here.
+        if start == end {
+            return Ok(());
+        }
+
+        let mut anon_ranges = self.anon_ranges.lock().expect("lock not poisoned");
+
+        // mprotect all the overlapping regions.
+        let mprotect_flags = op.mprotect_flags();
+        for range in anon_ranges.overlapping(ie(start, end)) {
+            let start = range.start();
+            // range.end() is inclusive, so we need to add 1 to get the length.
+            let len = (range.end() - start) + 1;
+            // SAFETY: this region was already mapped anonymously, so it's safe to call mprotect
+            // on it.
+            unsafe {
+                let ptr = self.memory.as_ptr().byte_add(start).cast();
+                mprotect(ptr, len, mprotect_flags)
+                    .err2anyhow()
+                    .with_context(|| format!("mprotect with {op:?} failed"))?;
+            }
+        }
+
+        if let Some(prot_flags) = op.mmap_prot_flags() {
+            // mmap all the gaps. We collect the gaps first because of the borrow checker: we can't
+            // insert into the set while iterating over it.
+            let gaps: Vec<_> = anon_ranges.gaps_trimmed(ie(start, end)).collect();
+
+            for range in gaps {
+                let start = range.start();
+                // range.end() is inclusive, so we need to add 1 to get the length.
+                let len = (range.end() - start) + 1;
+                unsafe {
+                    let ptr = self.memory.as_ptr().byte_add(start).cast();
+                    rustix::mm::mmap_anonymous(
+                        ptr,
+                        len,
+                        prot_flags,
+                        rustix::mm::MapFlags::PRIVATE
+                            | MMAP_NORESERVE_FLAG
+                            | rustix::mm::MapFlags::FIXED,
+                    )
+                    .err2anyhow()
+                    .with_context(|| format!("mmap_anonymous with {op:?} failed"))?;
+
+                    // TODO: call mprotect if required
+                }
+
+                // We might be tempted to insert the new region into the interval set in one big go at
+                // the end, but that is quite risky -- if the mmap fails, we would have to remove
+                // whatever parts failed from the interval set. It's much easier to insert each
+                // successful mmap into the set incrementally.
+                anon_ranges.insert_merge_touching_or_overlapping(ie(start, start + len));
+            }
+        }
+
+        Ok(())
+    }
+
+    unsafe fn map_fd(
+        &self,
+        start: usize,
+        fd: BorrowedFd<'_>,
+        len: usize,
+        offset: u64,
+    ) -> Result<()> {
+        let mut anon_ranges = self.anon_ranges.lock().expect("lock not poisoned");
+
+        let base = self.memory.as_ptr().byte_add(start).cast();
+        let ptr = rustix::mm::mmap(
+            base,
+            len,
+            rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
+            rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
+            fd,
+            offset,
+        )
+        .err2anyhow()?;
+        assert_eq!(base, ptr);
+
+        // TODO: should probably check that the new region doesn't overlap with existing regions.
+        anon_ranges.insert_merge_touching_or_overlapping(ie(start, start + len));
+
+        Ok(())
+    }
+
+    unsafe fn decommit(&self, range: Range<usize>) -> Result<()> {
+        if range.start == range.end {
+            return Ok(());
+        }
+
+        let mut anon_ranges = self.anon_ranges.lock().expect("lock not poisoned");
+
+        let start = range.start;
+        let end = range.end;
+
+        let base = self.memory.as_ptr().byte_add(start).cast();
+
+        // Remap the range as /dev/null.
+        let fd = File::open("/dev/null")
+            .err2anyhow()
+            .context("error opening /dev/null")?;
+        let ptr = unsafe {
+            rustix::mm::mmap(
+                base,
+                end - start,
+                rustix::mm::ProtFlags::empty(),
+                rustix::mm::MapFlags::PRIVATE | MMAP_NORESERVE_FLAG | rustix::mm::MapFlags::FIXED,
+                &fd,
+                0,
+            )
+            .err2anyhow()
+            .context("mmap call failed")?
+        };
+        assert_eq!(base, ptr);
+
+        // Clean out the range from the interval set.
+        let cut = NoditSet::from_iter_strict(anon_ranges.cut(ie(start, end)))
+            .expect("NoditSet::cut cannot return overlapping ranges");
+        *anon_ranges = cut;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum Op {
+    MakeAccessible,
+    MakeExecutable { enable_branch_protection: bool },
+    MakeReadonly,
+    MakeProtected,
+}
+
+impl Op {
+    fn mprotect_flags(&self) -> MprotectFlags {
+        match self {
+            Op::MakeAccessible => MprotectFlags::READ | MprotectFlags::WRITE,
+            Op::MakeExecutable {
+                enable_branch_protection,
+            } => {
+                let flags = MprotectFlags::READ | MprotectFlags::EXEC;
+                if *enable_branch_protection {
+                    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+                    if std::arch::is_aarch64_feature_detected!("bti") {
+                        MprotectFlags::from_bits_retain(flags.bits() | /* PROT_BTI */ 0x10)
+                    } else {
+                        flags
+                    }
+
+                    #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+                    flags
+                } else {
+                    flags
+                }
+            }
+            Op::MakeReadonly => MprotectFlags::READ,
+            Op::MakeProtected => MprotectFlags::empty(),
+        }
+    }
+
+    // None if new mmaps don't need to be created.
+    fn mmap_prot_flags(&self) -> Option<rustix::mm::ProtFlags> {
+        match self {
+            Op::MakeAccessible => Some(rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE),
+            Op::MakeExecutable { .. } => {
+                Some(rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::EXEC)
+            }
+            Op::MakeReadonly => Some(rustix::mm::ProtFlags::READ),
+            Op::MakeProtected => None,
+        }
+    }
+}
+
+impl Drop for MmapDevNull {
+    fn drop(&mut self) {
+        // munmap can work across multiple different mmap calls, so we can just munmap the entire
+        // memory in one go.
         unsafe {
             let ptr = self.memory.as_ptr().cast();
             let len = self.memory.as_ptr().len();


### PR DESCRIPTION
~~Giving up on this for now -- this ends up being a real challenge and may need a wider API redesign within wasmtime.~~

Used unsafe code to store a reference to the mapping without a supporting lifetime, and it works! The entire wast test suite passes:

```
test result: ok. 2492 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.00s
```